### PR TITLE
Added functions to Client.php to allow parameters to be passed in URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /coverage/
+/clover.xml

--- a/src/Client.php
+++ b/src/Client.php
@@ -213,6 +213,48 @@ final class Client
     {
         return $this->end($this->startGet($resource, $id));
     }
+    /**
+     * Get the details of an API resource based on $id and parameters
+     *
+     * @param string $resource
+     * @param string $id
+     * @param string $params Formatted parameter string, e.g., "realmId=5&minDate=1450674000&maxDate=1451278799"
+     * @param boolean $urlencode
+     *
+     * @return Response
+     */
+    public function startGetWithParams($resource, $id, $params, $urlencode)
+    {
+        $url = "{$this->_baseUrl}";
+        $url .= '/' . ($urlencode ? urlencode($resource) : $resource);
+        $url .= '/' . ($urlencode ? urlencode($id) : $id);
+        if (!empty($params)) {
+            $url .= '?' . ($urlencode ? urlencode($params) : $params);
+        }
+
+        return $this->_start($url, 'GET');
+    }
+
+    /**
+     * Get the details of an API resource based on $id and parameters
+     *
+     * @param string $resource
+     * @param string $id
+     * @param array $arParams Array of URL parameters 
+     * @param boolean $arOptions Array of options to apply in forming the URL string
+     *
+     * @return array Response
+     */
+    public function getWithParams($resource, $id, array $arParams = [], array $arOptions = [])
+    {
+        Util::throwIfNotType(['string' => [$resource, $id]], true);
+        // set options here.
+        $urlencode = array_key_exists('urlencode', $arOptions) ? $urlencode = $arOptions['urlencode'] : false;
+
+        $params = !empty($arParams) ? http_build_query($arParams) : '';
+
+        return $this->end($this->startGetWithParams($resource, $id, $params, $urlencode));
+    }
 
     /**
      * Create a new instance of an API resource using the provided $data

--- a/src/Client.php
+++ b/src/Client.php
@@ -39,6 +39,13 @@ final class Client
     const CACHE_MODE_ALL = 3;
 
     /**
+     * Flag to refresh cache on ALL requests
+     *
+     * @const int
+     */
+    const CACHE_MODE_REFRESH = 4;
+
+    /**
      * Base url of the API server
      *
      * @var string
@@ -129,7 +136,11 @@ final class Client
         Util::throwIfNotType(['string' => [$accessToken, $refreshToken]], true, true);
         Util::ensure(
             true,
-            in_array($cacheMode, [self::CACHE_MODE_NONE, self::CACHE_MODE_GET, self::CACHE_MODE_TOKEN, self::CACHE_MODE_ALL], true),
+            in_array(
+                $cacheMode,
+                [self::CACHE_MODE_NONE, self::CACHE_MODE_GET, self::CACHE_MODE_TOKEN, self::CACHE_MODE_ALL, self::CACHE_MODE_REFRESH],
+                true
+            ),
             '\InvalidArgumentException',
             ['$cacheMode must be a valid cache mode constant']
         );
@@ -304,7 +315,7 @@ final class Client
             $response = $this->_adapter->end($this->_adapter->start($request));
         }
 
-        if ($this->_cacheMode & self::CACHE_MODE_GET && $request->getMethod() === 'GET') {
+        if (($this->_cacheMode === self::CACHE_MODE_REFRESH || $this->_cacheMode & self::CACHE_MODE_GET) && $request->getMethod() === 'GET') {
             $this->_cache->set($request, $response);
         }
 
@@ -363,7 +374,7 @@ final class Client
 
         list($this->_accessToken, $this->_refreshToken, $expires) = Authentication::parseTokenResponse($response);
 
-        if ($this->_cacheMode & self::CACHE_MODE_TOKEN) {
+        if ($this->_cache === self::CACHE_MODE_REFRESH || $this->_cacheMode & self::CACHE_MODE_TOKEN) {
             $this->_cache->set($request, $response, $expires);
         }
     }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM nubs/phpunit
 
 USER root
 
-RUN pacman --sync --refresh --noconfirm --noprogressbar --quiet && pacman --sync --noconfirm --noprogressbar --quiet php-mongo
+RUN pacman-key --populate archlinux && pacman-key --refresh-keys && pacman --sync --refresh --noconfirm --noprogressbar --quiet && pacman --sync --refresh --sysupgrade --noconfirm --noprogressbar --quiet && pacman-db-upgrade && pacman --sync --noconfirm --noprogressbar --quiet php-mongo
 
 USER build
 


### PR DESCRIPTION
What does this PR do?
Added functions getWithParams and startGetWithParams to Client.php to allow parameters to be passed in a URL string in addition to resource and id. There are no changes to existing functions so there are no backward compatibility issues. 

Background
This change was necessary to support the new Nebulous ReportsController. This controller was added to support the ability of AWACS to pull the TOL Lead Reports Summary from Nebulous instead of querying Oracle directly (The report is accessed from the AWACS menu: Reports->Top Reports->TOL Lead Reports Summary).

With this change, realmId, start and end date are passed as parameters in the URL to the nebulous ReportsController which executes a sql query and returns the results. Previously, Client.php only supported passing of resource & id in the URL.

What are the relevant tickets?
MMT-203

What are the related pull requests?
1) TOL-Rec/tol PR PR #404
2) TOL-Arch/nebulous PR #459

What applications and/or websites is this PR expected to affect?
1) AWACS TopBusinessReport. The report is accessed from the AWACS menu: Reports->Top Reports->TOL Lead Reports Summary.
2) Nebulous ReportsController.php 

This change adds functions without changing any existing functions so there are no backward compatibility issues.  

Dependencies
None