### PR TITLE
Include Response interface in v2

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -6,7 +6,7 @@ use DominionEnterprises\Util;
 /**
  * Represents a response to an API request
  */
-final class Response
+final class Response implements ResponseInterface
 {
     /**
      * The http status of the response.

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DominionEnterprises\Api;
+
+/**
+ * Represents a response to an API request
+ */
+interface ResponseInterface
+{
+    /**
+     * Returns the HTTP status code of the response
+     *
+     * @return int
+     */
+    function getHttpCode();
+
+    /**
+     * Returns an array representing the response from the API
+     *
+     * @return array
+     */
+    function getResponse();
+
+    /**
+     * Returns the parsed response headers from the API
+     *
+     * @return array array where each header key has an array of values
+     */
+    function getResponseHeaders();
+}


### PR DESCRIPTION
Write the Response interface for v2 of the TOL API so we can continue to
have our tests pass in various internal projects.

Signed-off-by: Ryan Y <ryan.yakstis@dominionenterprises.com>