### PR TITLE
use strings as handles in GuzzleAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,12 @@ language: php
 php:
   - 7.0
   - 5.6
-env:
-  - EXT_VERSION=1.1 DB_PACKAGE=mongodb-10gen
-  - EXT_VERSION=1.1 DB_PACKAGE=mongodb-org
-services: 
+services:
   - redis-server
-before_install:
-  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
-  - "sudo apt-get update"
-  - "sudo apt-get install ${DB_PACKAGE}"
+  - mongodb
 before_script:
   - composer self-update || true
-  - yes '' | pecl install -f mongodb-${EXT_VERSION}
-    # wait for mongo, start is only needed for 2.4 package, see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
-  - sudo service mongodb start; bash -c 'while ! exec 6<>/dev/tcp/localhost/27017; do echo "$(date) - still trying to connect to mongo"; sleep 1; done'
+  - yes '' | pecl install -f mongodb-1.1
+  - bash -c 'while ! exec 6<>/dev/tcp/localhost/27017; do echo "$(date) - still trying to connect to mongo"; sleep 1; done'
 script: ./build.php
 after_script: ./vendor/bin/coveralls -v

--- a/src/GuzzleAdapter.php
+++ b/src/GuzzleAdapter.php
@@ -55,7 +55,8 @@ final class GuzzleAdapter implements Adapter
      */
     public function start(Request $request)
     {
-        $this->_promises[] = $this->_client->requestAsync(
+        $handle = uniqid();
+        $this->_promises[$handle] = $this->_client->requestAsync(
             $request->getMethod(),
             $request->getUrl(),
             [
@@ -64,8 +65,7 @@ final class GuzzleAdapter implements Adapter
             ]
         );
 
-        end($this->_promises);
-        return key($this->_promises);
+        return $handle;
     }
 
     /**
@@ -75,8 +75,6 @@ final class GuzzleAdapter implements Adapter
      */
     public function end($endHandle)
     {
-        Util::throwIfNotType(['int' => [$endHandle]]);
-
         $results = $this->fulfillPromises($this->_promises, $this->_exceptions);
         foreach ($results as $handle => $response) {
             try {


### PR DESCRIPTION
$handles must be unique per request. By using ints, we run the risk of repeating handles.