### PR TITLE
No longer use integers as adapter handles

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -300,7 +300,6 @@ final class Client implements ClientInterface
      */
     public function end($handle)
     {
-        Util::throwIfNotType(['int' => [$handle]]);
         Util::ensure(true, array_key_exists($handle, $this->_handles), '\InvalidArgumentException', ['$handle not found']);
 
         list($cachedResponse, $adapterHandle, $request) = $this->_handles[$handle];
@@ -434,14 +433,15 @@ final class Client implements ClientInterface
         if ($request->getMethod() === 'GET' && $this->_cacheMode & self::CACHE_MODE_GET) {
             $cached = $this->_cache->get($request);
             if ($cached !== null) {
-                $this->_handles[] = [$cached, null, $request];
-                end($this->_handles);
-                return key($this->_handles);
+                //The response is cache. Generate a key for the _handles array
+                $key = uniqid();
+                $this->_handles[$key] = [$cached, null, $request];
+                return $key;
             }
         }
 
-        $this->_handles[] = [null, $this->_adapter->start($request), $request];
-        end($this->_handles);
-        return key($this->_handles);
+        $key = $this->_adapter->start($request);
+        $this->_handles[$key] = [null, $key, $request];
+        return $key;
     }
 }


### PR DESCRIPTION
Recently the GuzzleAdapter was changed (#30) to return strings as request handles instead of integers. The Client was not updated to expect the strings and failed when asynchronous requests were attempted with the startX methods.