### PR TITLE
Add Collection::column()

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -186,4 +186,18 @@ final class Collection implements \Iterator, \Countable
 
         return $this->_result[$this->_position];
     }
+
+    /**
+     * Returns the values from a single field this collection, identified by the given $key.
+     *
+     * @param string $key The name of the field for which the values will be returned.
+     *
+     * @return iterable
+     */
+    public function column($key)
+    {
+        foreach ($this as $item) {
+            yield Util\Arrays::get($item, $key);
+        }
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -242,6 +242,23 @@ final class CollectionTest extends \PHPUnit_Framework_TestCase
             $this->assertSame(['id' => '0', 'key' => 0], $item);
         }
     }
+
+    /**
+     * Verifies basic behavior of column().
+     *
+     * @test
+     * @covers ::column
+     */
+    public function column()
+    {
+        $authentication = Authentication::createClientCredentials('not under test', 'not under test');
+        $client = new Client(new CollectionAdapter(), $authentication, 'not under test');
+        $collection = new Collection($client, 'basic', ['limit' => 3]);
+        $this->assertSame(
+            [0, 1, 2, 3, 4],
+            iterator_to_array($collection->column('key'))
+        );
+    }
 }
 
 final class CollectionAdapter implements Adapter


### PR DESCRIPTION
This pull request adds the `Collection::column()` method.  This will allow calling code to select a single value from the collection.

Example:
```php
$collection = new Collection($client, 'ads', ['status' => 'A',  'view' => 'full']);

foreach ($collection->column('id') as $id) {
    echo "{$id}\n";
}
```
Would produce output similar to
```sh
123
456
789

...
```